### PR TITLE
Allow custom RSS processing of non-standard feeds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ returns something like
   ]
 }
 ```
-##Custom Filters /{webapp-name}/rssTransform/prop/custom/{key}
+##Custom Filters /{webapp-name}/rssTransform/custom/{key}
 
 Custom filters allow you to consume an xml feed which is not in standard rss format, and return it as json using custom business logic you provide.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ returns something like
   ]
 }
 ```
-##Custom Filters /{webapp-name}/rssTransform/prop/{key}/xml
+##Custom Filters /{webapp-name}/rssTransform/prop/custom/{key}
 
 Custom filters allow you to consume an xml feed which is not in standard rss format, and return it as json using custom business logic you provide.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Converts RSS feeds to `JSON` (suitable for rendering with e.g. the RSS [widget type][angularjs-portal widgets docs] in [AngularJS-portal][]).
 
+There is also the functionality to plug in a custom XML for feeds which are not in a standard rss format.
+
 Intended for deployment as a "microservice".
 
 ## Confidence-inspiring badges
@@ -80,6 +82,13 @@ returns something like
   ]
 }
 ```
+##Custom Filters /{webapp-name}/rssTransform/prop/{key}/xml
+
+Custom filters allow you to consume an xml feed which is not in standard rss format, and return it as json using custom business logic you provide.
+
+As in the standard rss processor, {key} is the string identifying your feed. To utilize the custom filter, create a class which implements the iFilter interface.
+
+Give your class the case-insensitive name of your feed, plus the word "filter".. i.e. if your endpoint is sports=http://www.ncaa.com/news/ncaa/d1/rss.xml, then your class would be named SportsFilter.
 
 [AngularJS-portal]: https://github.com/UW-Madison-DoIT/angularjs-portal
 [angularjs-portal widgets docs]: http://uw-madison-doit.github.io/angularjs-portal/latest/#/md/widgets

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
             <artifactId>json</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.1.4</version>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>fluent-hc</artifactId>
+          <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -95,6 +95,11 @@
             <groupId>com.rometools</groupId>
             <artifactId>rome</artifactId>
             <version>1.7.0</version>
+        </dependency>
+        <dependency>
+          <groupId>nio</groupId>
+          <artifactId>nio</artifactId>
+          <version>1.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,11 +97,6 @@
             <version>1.7.0</version>
         </dependency>
         <dependency>
-          <groupId>nio</groupId>
-          <artifactId>nio</artifactId>
-          <version>1.0.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>json</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/src/main/java/edu/wisc/my/rssToJson/controller/RssToJsonController.java
+++ b/src/main/java/edu/wisc/my/rssToJson/controller/RssToJsonController.java
@@ -31,13 +31,13 @@ public class RssToJsonController {
         this.rssToJsonService = rssToJsonService;
     }
 
-    @RequestMapping(value="/rssTransform/{feed}/xml")
-    public @ResponseBody void getJsonifiedXMLUrl(HttpServletRequest request, HttpServletResponse response,
+    @RequestMapping(value="/rssTransform/custom/{feed}")
+    public @ResponseBody void customFeedAsJson(HttpServletRequest request, HttpServletResponse response,
             @PathVariable String feed) {
-
-        JSONObject jsonFromFeed = rssToJsonService.getJsonifiedXMLUrl(feed);
+        
+        JSONObject jsonFromFeed = rssToJsonService.getCustomizedUrl(feed);
         if (jsonFromFeed == null) {
-            logger.error("No feed for endpoint {}", feed);
+            logger.warn("No feed for endpoint {}", feed);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         } else {
             /* The filter is a custom class based on the name of your endpoint.
@@ -63,7 +63,7 @@ public class RssToJsonController {
     }
     
     @RequestMapping(value="/rssTransform/{feed}")
-    public @ResponseBody void getJsonifiedRssUrl(HttpServletRequest request,
+    public @ResponseBody void rssAsJson(HttpServletRequest request,
             HttpServletResponse response, @PathVariable String feed) {
         
         logger.debug("Attempting to retrieve feed for endpoint {}", feed);

--- a/src/main/java/edu/wisc/my/rssToJson/controller/RssToJsonController.java
+++ b/src/main/java/edu/wisc/my/rssToJson/controller/RssToJsonController.java
@@ -13,6 +13,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.beans.factory.BeanFactory;
+
+import edu.wisc.my.rssToJson.filter.XmlFilter;
+import edu.wisc.my.rssToJson.filter.iFilter;
 
 import edu.wisc.my.rssToJson.service.RssToJsonService;
 
@@ -25,6 +29,37 @@ public class RssToJsonController {
     @Autowired
     public void setRSSToJSONService(RssToJsonService rssToJsonService) {
         this.rssToJsonService = rssToJsonService;
+    }
+
+    @RequestMapping(value="/rssTransform/{feed}/xml")
+    public @ResponseBody void getJsonifiedXMLUrl(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable String feed) {
+
+        JSONObject jsonFromFeed = rssToJsonService.getJsonifiedXMLUrl(feed);
+        if (jsonFromFeed == null) {
+            logger.error("No feed for endpoint {}", feed);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        } else {
+            /* The filter is a custom class based on the name of your endpoint.
+             *  For example, if your feed is called "sports", then you should
+            // have a class in the filter package called "SportsFilter".
+            // All filter classes should implement the iFilter interface.
+            // 
+            // The static method XmlFilter.getXmlFilter(feed) will use
+            // reflection to return a filter with your custom business logic. 
+            */
+            iFilter filter = XmlFilter.getXmlFilter(feed);
+
+            JSONObject jsonToReturn = filter.getFilteredJSON(jsonFromFeed);
+            response.setContentType("application/json");
+            try {
+                response.getWriter().write(jsonToReturn.toString());
+                response.setStatus(HttpServletResponse.SC_OK);
+            } catch (IOException e) {
+                logger.warn(e.getMessage());
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+        }
     }
     
     @RequestMapping(value="/rssTransform/{feed}")

--- a/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDao.java
+++ b/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDao.java
@@ -1,9 +1,10 @@
 package edu.wisc.my.rssToJson.dao;
 
 import com.rometools.rome.feed.synd.SyndFeed;
+import org.json.JSONObject;
 
 public interface RssToJsonDao{
-    
+    public JSONObject getXMLFeed(String feedEndpoint);
     public SyndFeed getRssFeed(String feedEndpoint);
     
 }

--- a/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDao.java
+++ b/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDao.java
@@ -6,5 +6,6 @@ import org.json.JSONObject;
 public interface RssToJsonDao{
     public JSONObject getXMLFeed(String feedEndpoint);
     public SyndFeed getRssFeed(String feedEndpoint);
+    public String getEndpointURL(String feedEndpoint);
     
 }

--- a/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
@@ -43,12 +43,10 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
     void setEnv(Environment env) {
       this.env = env;
     }   
-    private String httpResponseAsString(String feedName) throws IOException {
-        logger.error("HTTP Response method " + feedName);
+    private String httpResponseAsString(String url) throws IOException {
+        logger.error("HTTP Response method " + url);
         CloseableHttpClient httpclient = HttpClients.createDefault();
         try {
-            String url = getEndpointURL(feedName);
-                         logger.error("ONE " + url);
             HttpGet httpget = new HttpGet(url);
             logger.error(httpget.toString());
 
@@ -69,8 +67,6 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
                     }
                 }
             };
-            logger.error("ONE POINT FIVE " + httpclient.toString());
-        
             String responseBody = httpclient.execute(httpget, responseHandler);
             logger.error("ONE POINT SIX " + responseBody);
             return responseBody;
@@ -94,7 +90,7 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
        return jsonObject;
    }
    
-   private String getEndpointURL(String feed) {
+   public String getEndpointURL(String feed) {
        logger.error("GETTING THE ENDPOINT FOR " + feed);
        String endpointURL = env.getProperty(feed);
        logger.error(endpointURL);
@@ -109,7 +105,6 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
     @Cacheable(cacheNames="feeds", sync=true)
     public SyndFeed getRssFeed(String feedEndpoint) {
       try{  
-        logger.error("INTO THE TRY");  
         String result = httpResponseAsString(feedEndpoint);
         SyndFeedInput input = new SyndFeedInput();
         InputStream stream = new ByteArrayInputStream(result.getBytes("UTF-8"));

--- a/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
@@ -62,7 +62,7 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
    }
    
    private String getEndpointURL(String feed) {
-       String endpointURL = getEndpointURL(feed);
+       String endpointURL = env.getProperty(feed);
        if (endpointURL == null) {
            logger.warn("No corresponding feed url for requested endpoint {}", feed);
            return null;

--- a/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.rssToJson.dao;
 
+import java.io.InputStream;
 import java.io.InputStreamReader;
 
 import org.apache.http.HttpHeaders;
@@ -7,6 +8,9 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.JSONObject;
+import org.json.XML;
+import javax.json.JsonReader;  
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +36,39 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
     void setEnv(Environment env) {
       this.env = env;
     }
+
+    @Override
+    public JSONObject getXMLFeed(String feedEndpoint) {
+       String endpointURL = getEndpointURL(feedEndpoint);
+       JSONObject jsonObject = null;
+       try {
+           HttpClient client = HttpClientBuilder.create().build();
+           HttpGet request = new HttpGet(endpointURL);
+           request.setHeader(HttpHeaders.USER_AGENT, "rss-to-json service");
+           HttpResponse response = client.execute(request);
+           InputStreamReader isr = new InputStreamReader(response.getEntity().getContent());
+           StringBuffer stringBuffer = new StringBuffer();
+           int i;
+           while ((i = isr.read()) != -1) {
+               stringBuffer.append((char) i);
+           }
+           String xmlString = stringBuffer.toString();
+           jsonObject = XML.toJSONObject(xmlString);
+       } catch (Exception e) {
+           logger.warn(e.getMessage());
+           return null;
+       }
+       return jsonObject;
+   }
+   
+   private String getEndpointURL(String feed) {
+       String endpointURL = getEndpointURL(feed);
+       if (endpointURL == null) {
+           logger.warn("No corresponding feed url for requested endpoint {}", feed);
+           return null;
+       }
+       return endpointURL;
+   }
 
     @Override
     @Cacheable(cacheNames="feeds", sync=true)

--- a/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/dao/RssToJsonDaoImpl.java
@@ -2,15 +2,22 @@ package edu.wisc.my.rssToJson.dao;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import org.apache.http.HttpHeaders;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.JSONObject;
 import org.json.XML;
-import javax.json.JsonReader;  
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils; 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,25 +42,51 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
     @Autowired
     void setEnv(Environment env) {
       this.env = env;
+    }   
+    private String httpResponseAsString(String feedName) throws IOException {
+        logger.error("HTTP Response method " + feedName);
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        try {
+            String url = getEndpointURL(feedName);
+                         logger.error("ONE " + url);
+            HttpGet httpget = new HttpGet(url);
+            logger.error(httpget.toString());
+
+            // Create a custom response handler
+            ResponseHandler<String> responseHandler = new ResponseHandler<String>() {
+
+                @Override
+                public String handleResponse(
+                        final HttpResponse response) throws ClientProtocolException, IOException {
+                     logger.error("TWO " + response.toString());        
+                    int status = response.getStatusLine().getStatusCode();
+                    logger.debug(status + " response code ");
+                    if (status >= 200 && status < 300) {
+                        HttpEntity entity = response.getEntity();
+                        return entity != null ? EntityUtils.toString(entity) : null;
+                    } else {
+                        throw new ClientProtocolException("Unexpected response status: " + status);
+                    }
+                }
+            };
+            logger.error("ONE POINT FIVE " + httpclient.toString());
+        
+            String responseBody = httpclient.execute(httpget, responseHandler);
+            logger.error("ONE POINT SIX " + responseBody);
+            return responseBody;
+        } finally {
+            httpclient.close();
+        }
     }
+
 
     @Override
     public JSONObject getXMLFeed(String feedEndpoint) {
        String endpointURL = getEndpointURL(feedEndpoint);
        JSONObject jsonObject = null;
        try {
-           HttpClient client = HttpClientBuilder.create().build();
-           HttpGet request = new HttpGet(endpointURL);
-           request.setHeader(HttpHeaders.USER_AGENT, "rss-to-json service");
-           HttpResponse response = client.execute(request);
-           InputStreamReader isr = new InputStreamReader(response.getEntity().getContent());
-           StringBuffer stringBuffer = new StringBuffer();
-           int i;
-           while ((i = isr.read()) != -1) {
-               stringBuffer.append((char) i);
-           }
-           String xmlString = stringBuffer.toString();
-           jsonObject = XML.toJSONObject(xmlString);
+         String xmlString = httpResponseAsString(endpointURL);
+         jsonObject = XML.toJSONObject(xmlString);
        } catch (Exception e) {
            logger.warn(e.getMessage());
            return null;
@@ -62,7 +95,9 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
    }
    
    private String getEndpointURL(String feed) {
+       logger.error("GETTING THE ENDPOINT FOR " + feed);
        String endpointURL = env.getProperty(feed);
+       logger.error(endpointURL);
        if (endpointURL == null) {
            logger.warn("No corresponding feed url for requested endpoint {}", feed);
            return null;
@@ -73,31 +108,20 @@ public class RssToJsonDaoImpl implements RssToJsonDao{
     @Override
     @Cacheable(cacheNames="feeds", sync=true)
     public SyndFeed getRssFeed(String feedEndpoint) {
-        logger.info("Fetching feed for {} ", feedEndpoint);
-        //see if property file has corresponding url for requested endpoint
-        String endpointURL = env.getProperty(feedEndpoint);
-        if (endpointURL == null){
-          logger.warn("No corresponding feed url for requested endpoint {}",
-                  feedEndpoint);
-          return null;
-        }
-        SyndFeed feed = null;
-        try{
-            HttpClient client = HttpClientBuilder.create().build();
-            HttpGet request = new HttpGet(endpointURL);
-            request.setHeader(HttpHeaders.USER_AGENT, "rss-to-json service");
-            request.setHeader(HttpHeaders.CONTENT_ENCODING, "UTF-8");
-            HttpResponse response = client.execute(request);
-            SyndFeedInput input = new SyndFeedInput();
-            feed = input.build(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
-            feed.setFeedType("UTF-8");
-            logger.debug("CONTENT OF FEED " + endpointURL);
-            logger.debug(feed.toString());
-
-        }catch(Exception ex){
-            logger.error("Error while fetching xml from {}", endpointURL, ex);
-        }
+      try{  
+        logger.error("INTO THE TRY");  
+        String result = httpResponseAsString(feedEndpoint);
+        SyndFeedInput input = new SyndFeedInput();
+        InputStream stream = new ByteArrayInputStream(result.getBytes("UTF-8"));
+        SyndFeed feed = input.build(new InputStreamReader(stream, "UTF-8"));
+        logger.debug("CONTENT OF FEED " + feedEndpoint);
+        logger.debug(feed.toString());
         return feed;
+      } catch (Exception e) {
+          logger.warn("Could not get feed " + feedEndpoint + " " + e.getMessage());
+      } 
+
+      return null;
     }
 
 }

--- a/src/main/java/edu/wisc/my/rssToJson/filter/WudFilter.java
+++ b/src/main/java/edu/wisc/my/rssToJson/filter/WudFilter.java
@@ -1,0 +1,53 @@
+package edu.wisc.my.rssToJson.filter;
+ import java.util.Iterator;
+ import org.json.JSONArray;
+import org.json.JSONObject;
+ import java.util.ArrayList;
+ import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+ import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+ public class WudFilter implements iFilter{
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+     public WudFilter(){
+    }
+     public JSONObject getFilteredJSON(JSONObject rawJSON){
+        ObjectMapper om = new ObjectMapper();
+        JSONObject responseObj = new JSONObject();
+        JSONObject feedInfo = new JSONObject();
+         try{
+            JsonNode rootNode = om.readTree(rawJSON.toString());
+            feedInfo.put("title", rootNode.findValue("title").asText());
+            feedInfo.put("link", "https://union.wisc.edu/events-and-activities/event-calendar/");
+            feedInfo.put("description", rootNode.findValue("description").asText());
+            feedInfo.put("pubDate", rootNode.findValue("lastBuildDate").asText());
+            
+            
+            JsonNode events = rootNode.findValue("event");
+  
+            Iterator<JsonNode> iter = events.elements();
+             ArrayList<JSONObject> eventNodes = new ArrayList();
+            
+            while(iter.hasNext()){
+                JSONObject item = new JSONObject();
+                JsonNode anEvent = iter.next();
+                item.put("title", anEvent.findValue("event_title").asText());
+                item.put("link", anEvent.findValue("url").asText());
+                item.put("description",anEvent.findValue("short_description").asText());
+                JSONObject thisItem = new JSONObject();
+                thisItem.put("item", item);
+                eventNodes.add(thisItem);
+            }
+             JSONArray allEvents = new JSONArray(eventNodes);
+            feedInfo.put("items",allEvents);
+             
+        }catch(Exception e){
+            logger.error(e.getMessage());
+        };
+         return feedInfo;
+    }
+     public String healthCheck(){
+        return "WudFilter health check";
+    }     
+} 

--- a/src/main/java/edu/wisc/my/rssToJson/filter/WudFilter.java
+++ b/src/main/java/edu/wisc/my/rssToJson/filter/WudFilter.java
@@ -14,8 +14,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
     }
      public JSONObject getFilteredJSON(JSONObject rawJSON){
         ObjectMapper om = new ObjectMapper();
-        JSONObject responseObj = new JSONObject();
         JSONObject feedInfo = new JSONObject();
+        JSONObject feed = new JSONObject();
+        JSONArray items = new JSONArray();
          try{
             JsonNode rootNode = om.readTree(rawJSON.toString());
             feedInfo.put("title", rootNode.findValue("title").asText());
@@ -27,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
             JsonNode events = rootNode.findValue("event");
   
             Iterator<JsonNode> iter = events.elements();
-             ArrayList<JSONObject> eventNodes = new ArrayList();
             
             while(iter.hasNext()){
                 JSONObject item = new JSONObject();
@@ -35,17 +35,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
                 item.put("title", anEvent.findValue("event_title").asText());
                 item.put("link", anEvent.findValue("url").asText());
                 item.put("description",anEvent.findValue("short_description").asText());
-                JSONObject thisItem = new JSONObject();
-                thisItem.put("item", item);
-                eventNodes.add(thisItem);
+                items.put(item);
             }
-             JSONArray allEvents = new JSONArray(eventNodes);
-            feedInfo.put("items",allEvents);
+            feed.put("feed", feedInfo);
+            feed.put("items",items);
+
              
         }catch(Exception e){
             logger.error(e.getMessage());
         };
-         return feedInfo;
+         feed.put("status", "ok");
+         return feed;
     }
      public String healthCheck(){
         return "WudFilter health check";

--- a/src/main/java/edu/wisc/my/rssToJson/filter/XmlFilter.java
+++ b/src/main/java/edu/wisc/my/rssToJson/filter/XmlFilter.java
@@ -1,0 +1,35 @@
+package edu.wisc.my.rssToJson.filter;
+ import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+ public class XmlFilter {
+     protected final Logger logger = LoggerFactory.getLogger(getClass());
+     public static iFilter getXmlFilter(String filterName){
+        try{ 
+          String filterClass = XmlFilter.toTitleCase(filterName) + "Filter";
+          String pkg = new CurrentClassGetter().getPackageName();
+          iFilter filter = (iFilter) Class.forName(pkg + "." +filterClass).newInstance();
+          return filter;
+       } catch (Exception e){
+           return null;
+       }
+    }
+    public static class CurrentClassGetter extends SecurityManager {
+    public String getPackageName() {
+      return getClassContext()[1].getPackage().getName(); 
+    }
+  }
+     private static String toTitleCase(String filterNameIn){
+        StringBuilder titleCase = new StringBuilder();
+        boolean nextTitleCase = true;
+        for (char c : filterNameIn.toCharArray()) {
+             if (nextTitleCase) {
+                 c = Character.toTitleCase(c);
+                 nextTitleCase = false;
+             }
+     
+             titleCase.append(c);
+         }
+         String filterNameOut = titleCase.toString().trim();
+        return filterNameOut;
+    }
+ }

--- a/src/main/java/edu/wisc/my/rssToJson/filter/iFilter.java
+++ b/src/main/java/edu/wisc/my/rssToJson/filter/iFilter.java
@@ -1,0 +1,6 @@
+package edu.wisc.my.rssToJson.filter;
+ import org.json.JSONObject;
+ public interface iFilter{
+    public JSONObject getFilteredJSON(JSONObject rawJSON);
+    public String healthCheck();
+}

--- a/src/main/java/edu/wisc/my/rssToJson/service/RssToJsonService.java
+++ b/src/main/java/edu/wisc/my/rssToJson/service/RssToJsonService.java
@@ -5,5 +5,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface RssToJsonService {
+	public JSONObject getJsonifiedXMLUrl(String feed);
 	public JSONObject getJsonFromURL(String url);
 }

--- a/src/main/java/edu/wisc/my/rssToJson/service/RssToJsonService.java
+++ b/src/main/java/edu/wisc/my/rssToJson/service/RssToJsonService.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface RssToJsonService {
-	public JSONObject getJsonifiedXMLUrl(String feed);
+	public JSONObject getCustomizedUrl(String feed);
 	public JSONObject getJsonFromURL(String url);
 }

--- a/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java
@@ -2,11 +2,9 @@ package edu.wisc.my.rssToJson.service;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.json.XML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.context.annotation.Primary;
 
@@ -29,7 +27,8 @@ public class RsstoJsonServiceImpl implements RssToJsonService {
 
     @Override
     public JSONObject getJsonFromURL(String endpoint) {
-        SyndFeed feed = rssToJsonDao.getRssFeed(endpoint);
+        String url = rssToJsonDao.getEndpointURL(endpoint);
+        SyndFeed feed = rssToJsonDao.getRssFeed(url);
         if(feed == null){
             logger.warn("No feed returned for endpoint: {}", endpoint);
             return null;
@@ -62,8 +61,8 @@ public class RsstoJsonServiceImpl implements RssToJsonService {
     }
 
     @Override
-    public JSONObject getJsonifiedXMLUrl(String feed) {
-        JSONObject xmlJSONObj = rssToJsonDao.getXMLFeed(feed);
+    public JSONObject getCustomizedUrl(String endpoint) {
+        JSONObject xmlJSONObj = rssToJsonDao.getXMLFeed(endpoint);
         return xmlJSONObj;
     }
 }

--- a/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java
@@ -12,8 +12,8 @@ import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 
 import edu.wisc.my.rssToJson.dao.RssToJsonDao;
-@Primary
 
+@Primary
 @Service
 public class RsstoJsonServiceImpl implements RssToJsonService {
     protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java
+++ b/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java
@@ -2,17 +2,19 @@ package edu.wisc.my.rssToJson.service;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.json.XML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Primary;
 
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 
 import edu.wisc.my.rssToJson.dao.RssToJsonDao;
-
+@Primary
 
 @Service
 public class RsstoJsonServiceImpl implements RssToJsonService {
@@ -57,5 +59,11 @@ public class RsstoJsonServiceImpl implements RssToJsonService {
         // replace en-dash with minus
         stringToClean = stringToClean.replaceAll("\\\\u2014", "-");
         return new JSONObject(stringToClean);
+    }
+
+    @Override
+    public JSONObject getJsonifiedXMLUrl(String feed) {
+        JSONObject xmlJSONObj = rssToJsonDao.getXMLFeed(feed);
+        return xmlJSONObj;
     }
 }

--- a/src/main/resources/endpoint.properties
+++ b/src/main/resources/endpoint.properties
@@ -12,4 +12,5 @@ uwp-news=https://www.uwp.edu/explore/media/rss.xml
 working-at-uw=https://working.wisc.edu/feed/
 uw-system-payroll-benefits-news=https://uwservice.wisconsin.edu/news/feed/B
 xkcd=http://xkcd.com/rss.xml
+wud=https://union.wisc.edu/events-and-activities/event-calendar/feed/wud.xml
 sample=https://raw.githubusercontent.com/UW-Madison-DoIT/rssToJson/master/src/main/resources/sampleFile.rss

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -52,7 +52,7 @@
   <root level="ERROR">
       <appender-ref ref="LOG"/>
   </root>
-  <logger name="edu.wisc" additivity="false" level="WARN">
+  <logger name="edu.wisc" additivity="false" level="ERROR">
         <appender-ref ref="LOG"/>
     </logger>
 


### PR DESCRIPTION
Using reflection, allow a filter class to be associated to an endpoint. We can then write custom code and force non-standard content into a consumable RSS feed. 

For example, the Union's event calendar is not in a standard rss format. 

https://union.wisc.edu/events-and-activities/event-calendar/feed/wud.xml

When hitting ...
{hostname}/rssTransform/wud/xml

the /xml at the end of the URL tells the microservice to seek out a filter class with the name "wud". 