### PR TITLE
Filter away byte order markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next (1.0.9?)
 
++ When reading the remote feed, wrap it in a BOMInputStream
+  to filter away any leading Byte Order Marker if present.
 + Reject responses larger than 1 million bytes,
   to reduce impact to system from unreasonably large RSS feed responses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change log
+
+## Next (1.0.9?)
+
++ Reject responses larger than 1 million bytes,
+  to reduce impact to system from unreasonably large RSS feed responses.
+
+(Versions older than 1.0.9 predated this change log.)

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache</artifactId>
         </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.4</version>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,14 @@
                   <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>8</source>
+              <target>8</target>
+            </configuration>
+          </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Filter away leading byte order markers where present, as these can interfere with parsing the XML response.

Observed: `[Invalid XML: Error on line 1: Content is not allowed in prolog`, which [might be caused by the presence of a byte order mark](https://stackoverflow.com/questions/4569123/content-is-not-allowed-in-prolog-saxparserexception) which can be filtered away.